### PR TITLE
Leader step down when removing itself

### DIFF
--- a/doc/manual/using.adoc
+++ b/doc/manual/using.adoc
@@ -258,7 +258,20 @@ The steps to add a member are as follows (say we have `RAFT.members="A,B,C"` and
 * A new member `D` can now be started (its XML config needs to have the correct `members` attribute !)
 
 Notice that membership changes survive through restarts. If a node must be removed or added, an operation must be
-submitted, only restarting does not affect membership.
+submitted, only shutting down the node does not affect membership.
 
+Contrary to the reconfiguration defined in the Raft article, jgroups-raft only applies the membership change after the operation is committed.
+This does not violate safety, as there is still an intersection between the old and new configuration.
 
+WARNING: Currently, there are no safeguards to guarantee the quorum is maintained after a node is removed.
+It is advised to check the leader's view before applying a removal operation until safeguards are included.
 
+==== Removing the leader
+
+The leader can self-remove from the configuration.
+After the operation is committed and the leader applies it to the state machine, the leader will step down and trigger a new election.
+This causes any enqueued or outstanding request to be completed exceptionally since the leader transitions to a follower.
+
+Removing the leader in a two-node cluster and the leader crashes before the second node applies the operation to the state machine renders the cluster unavailable.
+The same problem applies to any other operation when the cluster has less than a majority of nodes available.
+The recommendation is to utilize more nodes in the cluster.

--- a/src/org/jgroups/protocols/raft/InternalCommand.java
+++ b/src/org/jgroups/protocols/raft/InternalCommand.java
@@ -1,5 +1,6 @@
 package org.jgroups.protocols.raft;
 
+import org.jgroups.protocols.raft.election.BaseElection;
 import org.jgroups.util.Bits;
 import org.jgroups.util.Streamable;
 
@@ -43,6 +44,8 @@ public class InternalCommand implements Streamable {
                 break;
             case removeServer:
                 raft._removeServer(name);
+                BaseElection be = raft.getProtocolStack().findProtocol(BaseElection.class);
+                if (be != null) be.raftServerRemoved(name);
                 break;
         }
         return null;

--- a/src/org/jgroups/protocols/raft/PersistentState.java
+++ b/src/org/jgroups/protocols/raft/PersistentState.java
@@ -28,6 +28,16 @@ public class PersistentState implements SizeStreamable {
         return new ArrayList<>(members);
     }
 
+    /**
+     * Verify if the given member is a member of the current members list.
+     *
+     * @param raftId: The Raft ID to verify.
+     * @return <code>true</code> if the Raft ID is a current member. <code>false</code>, otherwise.
+     */
+    public boolean containsMember(String raftId) {
+        return members.contains(raftId);
+    }
+
     public void setMembers(Collection<String> value) {
         members.clear();
         members.addAll(new HashSet<>(value));

--- a/src/org/jgroups/protocols/raft/RAFT.java
+++ b/src/org/jgroups/protocols/raft/RAFT.java
@@ -14,6 +14,7 @@ import org.jgroups.raft.StateMachine;
 import org.jgroups.raft.util.CommitTable;
 import org.jgroups.raft.util.LogCache;
 import org.jgroups.raft.util.RequestTable;
+import org.jgroups.raft.util.Utils;
 import org.jgroups.stack.Protocol;
 import org.jgroups.util.*;
 
@@ -1070,6 +1071,18 @@ public class RAFT extends Protocol implements Settable, DynamicMembership {
                 log.error("%s: failed snapshotting log: %s", local_addr, ex);
             }
         }
+    }
+
+    /**
+     * Verify if the node identified by the given address is a Raft member.
+     *
+     * @param address: The node address to verify.
+     * @return <code>true</code> if the address is present in the current members. <code>false</code>, otherwise.
+     * @see Utils#extractRaftId(Address)
+     */
+    public boolean isRaftMember(Address address) {
+        String raftId = Utils.extractRaftId(address);
+        return raftId != null && internal_state.containsMember(raftId);
     }
 
     /**

--- a/src/org/jgroups/raft/util/Utils.java
+++ b/src/org/jgroups/raft/util/Utils.java
@@ -4,6 +4,8 @@ import org.jgroups.Address;
 import org.jgroups.View;
 import org.jgroups.protocols.raft.RAFT;
 import org.jgroups.raft.testfwk.RaftTestUtils;
+import org.jgroups.util.ExtendedUUID;
+import org.jgroups.util.Util;
 
 /**
  * @author Bela Ban
@@ -47,4 +49,24 @@ public class Utils {
         RaftTestUtils.deleteRaftLog(r);
     }
 
+    /**
+     * Extract the Raft ID from the given address instance.
+     * <p>
+     * During creation, the node embed it's ID in the address. It needs to be an instance of
+     * {@link ExtendedUUID} to hold the information.
+     * </p>
+     *
+     * @param address: The {@link Address} to extract the Raft ID.
+     * @return The Raft ID embedded in the address, or <code>null</code>, otherwise.
+     */
+    public static String extractRaftId(Address address) {
+        if (!(address instanceof ExtendedUUID))
+            return null;
+
+        ExtendedUUID uuid = (ExtendedUUID) address;
+        byte[] value = uuid.get(RAFT.raft_id_key);
+        return value == null
+                ? null
+                : Util.bytesToString(value);
+    }
 }

--- a/tests/junit-functional/org/jgroups/tests/harness/BaseRaftChannelTest.java
+++ b/tests/junit-functional/org/jgroups/tests/harness/BaseRaftChannelTest.java
@@ -126,6 +126,24 @@ public class BaseRaftChannelTest extends AbstractRaftTest {
     }
 
     /**
+     * Close the {@link JChannel} with the given index.
+     * <p>
+     * This method only closes the channel and remove the instance.
+     * All the underlying state is still kept.
+     * </p>
+     *
+     * @param index: Channel index to close.
+     * @throws Exception: If an error happens while closing the channel.
+     */
+    protected final void shutdown(int index) throws Exception {
+        JChannel ch = channel(index);
+        if (ch == null) return;
+
+        channels[index] = null;
+        Util.close(ch);
+    }
+
+    /**
      * Closes the given channel and deletes the {@link RAFT} state.
      *
      * @param ch: The {@link JChannel} to close.


### PR DESCRIPTION
Opening a PR since it touches the election part a bit.

The idea here is to check the election implementation after removing a member. If the current leader is removing itself, it steps down locally to stop accepting subsequent requests. Then, the old leader starts the voting thread to collect information from the other RAFT members. More details are listed in the issue tracker, but the idea here borrows a bit from the leader transfer in the Raft dissertation.

A leader needs to have an up-to-date log. After the membership change is committed, there are a majority of nodes with a recent log. Therefore, we can safely start an election round with the remaining members.

The change in the election is to request the RAFT members instead of the view members. Executing the test and Jepsen suites doesn't show any problem with this restriction. We could enhance the test coverage here. One interesting test scenario would enqueue a few requests and execute the leader removal. I plan to extend the test suite in future changes, so I'll make a note of that.

Closes #246.