### PR TITLE
Handle view changes during election

### DIFF
--- a/src/org/jgroups/protocols/raft/election/BaseElection.java
+++ b/src/org/jgroups/protocols/raft/election/BaseElection.java
@@ -325,7 +325,7 @@ public abstract class BaseElection extends Protocol {
                     local_addr, votes.getValidResults(), time, majority);
     }
 
-    private boolean isMajorityAvailable() {
+    protected final boolean isMajorityAvailable() {
         return view != null && view.size() >= raft.majority();
     }
 

--- a/src/org/jgroups/raft/util/Utils.java
+++ b/src/org/jgroups/raft/util/Utils.java
@@ -5,6 +5,8 @@ import org.jgroups.View;
 import org.jgroups.protocols.raft.RAFT;
 import org.jgroups.raft.testfwk.RaftTestUtils;
 
+import java.util.Objects;
+
 /**
  * @author Bela Ban
  * @since  1.0.6
@@ -30,6 +32,18 @@ public class Utils {
         if(leader != null && !new_view.containsMember(leader))
             return Majority.leader_lost;
         return Majority.no_change;
+    }
+
+    /**
+     * Verify if the coordinator change between two views.
+     *
+     * @param prev: The old {@link View}, it can be <code>null</code>.
+     * @param curr: The recent {@link View}.
+     * @return <code>true</code> if the coordinator changed, <code>false</code>, otherwise.
+     */
+    public static boolean viewCoordinatorChanged(View prev, View curr) {
+        if (prev == null) return true;
+        return !Objects.equals(prev.getCoord(), curr.getCoord());
     }
 
     /**

--- a/tests/junit-functional/org/jgroups/tests/election/NetworkPartitionElectionTest.java
+++ b/tests/junit-functional/org/jgroups/tests/election/NetworkPartitionElectionTest.java
@@ -1,0 +1,119 @@
+package org.jgroups.tests.election;
+
+import org.jgroups.Address;
+import org.jgroups.Global;
+import org.jgroups.Header;
+import org.jgroups.View;
+import org.jgroups.protocols.raft.RAFT;
+import org.jgroups.protocols.raft.election.LeaderElected;
+import org.jgroups.raft.testfwk.BlockingMessageInterceptor;
+import org.jgroups.raft.testfwk.PartitionedRaftCluster;
+import org.jgroups.raft.testfwk.RaftTestUtils;
+import org.jgroups.tests.harness.BaseRaftElectionTest;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jgroups.tests.harness.BaseRaftElectionTest.ALL_ELECTION_CLASSES_PROVIDER;
+
+@Test(groups = Global.FUNCTIONAL, singleThreaded = true, dataProvider = ALL_ELECTION_CLASSES_PROVIDER)
+public class NetworkPartitionElectionTest extends BaseRaftElectionTest.ClusterBased<PartitionedRaftCluster> {
+
+    {
+        clusterSize = 5;
+
+        // Since it uses a data provider, it needs to execute per method to inject the values.
+        recreatePerMethod = true;
+    }
+
+    public void testNetworkPartitionDuringElection(Class<?> ignore) throws Exception {
+        withClusterSize(5);
+        createCluster();
+        long id = 0;
+
+        View view = createView(id++, 0, 1, 2, 3, 4);
+
+        // We intercept the first `LeaderElected` message.
+        AtomicBoolean onlyOnce = new AtomicBoolean(true);
+        BlockingMessageInterceptor interceptor = cluster.addCommandInterceptor(m -> {
+            for (Map.Entry<Short, Header> h : m.getHeaders().entrySet()) {
+                if (h.getValue() instanceof LeaderElected && onlyOnce.getAndSet(false)) {
+                    // Assert that node A was elected
+                    LeaderElected le = (LeaderElected) h.getValue();
+                    assertThat(le.leader()).isEqualTo(address(0));
+                    return true;
+                }
+            }
+            return false;
+        });
+
+        cluster.handleView(view);
+
+        System.out.println("-- wait command intercept");
+        assertThat(RaftTestUtils.eventually(() -> interceptor.numberOfBlockedMessages() > 0, 10, TimeUnit.SECONDS)).isTrue();
+
+        // While the message is in-flight, the cluster splits.
+        // The previous coordinator does not have the majority to proceed.
+        cluster.handleView(createView(id++, 0, 1));
+        cluster.handleView(createView(id++, 2, 3, 4));
+
+        // We can release the elected message.
+        interceptor.releaseNext();
+        interceptor.assertNoBlockedMessages();
+
+        // Check in all instances that a new leader is elected.
+        System.out.println("-- waiting for leader in majority partition");
+        BaseRaftElectionTest.waitUntilLeaderElected(rafts(), 10_000);
+
+        // Assert that A and B does not have a leader.
+        assertThat(raft(0).leader()).isNull();
+        assertThat(raft(1).leader()).isNull();
+
+        System.out.printf("-- elected during the split\n%s%n", dumpLeaderAndTerms());
+        // Store who's the leader before merging.
+        assertThat(leaders()).hasSize(1);
+        RAFT leader = raft(leaders().get(0));
+        long leaderTermBefore = leader.currentTerm();
+
+        System.out.printf("-- merge partition, leader=%s%n", leader);
+        // Join the partitions.
+        // Note that the coordinator is different.
+        cluster.handleView(createView(id++, 0, 1, 2, 3, 4));
+
+        // Wait until A and B receive the leader information.
+        BaseRaftElectionTest.waitUntilAllHaveLeaderElected(rafts(), 10_000);
+        System.out.printf("-- state after merge\n%s%n", dumpLeaderAndTerms());
+
+        // We assert the merge did not disrupt the cluster.
+        // Same leader and term.
+        assertThat(Arrays.stream(rafts())
+                .allMatch(r -> Objects.equals(leader.getAddress(), r.leader()) && r.currentTerm() == leaderTermBefore))
+                .withFailMessage(this::dumpLeaderAndTerms)
+                .isTrue();
+    }
+
+    private RAFT raft(Address address) {
+        for (RAFT raft : rafts()) {
+            if (Objects.equals(address, raft.getAddress()))
+                return raft;
+        }
+
+        throw new IllegalArgumentException(String.format("Node with address '%s' not present", address));
+    }
+
+    @Override
+    protected PartitionedRaftCluster createNewMockCluster() {
+        return new PartitionedRaftCluster();
+    }
+
+    @Override
+    protected void amendRAFTConfiguration(RAFT raft) {
+        raft.synchronous(true);
+    }
+}

--- a/tests/junit-functional/org/jgroups/tests/election/ViewChangeElectionTest.java
+++ b/tests/junit-functional/org/jgroups/tests/election/ViewChangeElectionTest.java
@@ -1,0 +1,209 @@
+package org.jgroups.tests.election;
+
+import org.jgroups.Address;
+import org.jgroups.Global;
+import org.jgroups.Header;
+import org.jgroups.View;
+import org.jgroups.protocols.raft.Log;
+import org.jgroups.protocols.raft.LogEntries;
+import org.jgroups.protocols.raft.LogEntry;
+import org.jgroups.protocols.raft.RAFT;
+import org.jgroups.protocols.raft.election.LeaderElected;
+import org.jgroups.raft.testfwk.BlockingMessageInterceptor;
+import org.jgroups.raft.testfwk.RaftCluster;
+import org.jgroups.raft.testfwk.RaftNode;
+import org.jgroups.raft.testfwk.RaftTestUtils;
+import org.jgroups.tests.DummyStateMachine;
+import org.jgroups.tests.harness.BaseRaftElectionTest;
+import org.jgroups.tests.harness.RaftAssertion;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jgroups.tests.harness.BaseRaftElectionTest.ALL_ELECTION_CLASSES_PROVIDER;
+
+@Test(groups = Global.FUNCTIONAL, singleThreaded = true, dataProvider = ALL_ELECTION_CLASSES_PROVIDER)
+public class ViewChangeElectionTest extends BaseRaftElectionTest.ClusterBased<RaftCluster> {
+
+    private static final byte[] BUF = {};
+
+
+    {
+        createManually = true;
+    }
+
+    @AfterMethod
+    protected void destroy() throws Exception {
+        destroyCluster();
+    }
+
+    @Override
+    protected RaftCluster createNewMockCluster() {
+        return new RaftCluster();
+    }
+
+    public void testLeaderLostAfterElected(Class<?> ignore) throws Exception {
+        long view_id = 0;
+        withClusterSize(3);
+        createCluster();
+
+        // Define the longest log for C, so it can be the leader.
+        setLog(raft(2), 1, 1, 1, 1);
+
+        View view = createView(view_id++, 0, 1, 2);
+
+        // We intercept the first `LeaderElected` message.
+        AtomicBoolean onlyOnce = new AtomicBoolean(true);
+        BlockingMessageInterceptor interceptor = cluster.addCommandInterceptor(m -> {
+            for (Map.Entry<Short, Header> h : m.getHeaders().entrySet()) {
+                if (h.getValue() instanceof LeaderElected && onlyOnce.getAndSet(false)) {
+                    // Assert that node C was elected
+                    LeaderElected le = (LeaderElected) h.getValue();
+                    assertThat(le.leader()).isEqualTo(address(2));
+                    return true;
+                }
+            }
+            return false;
+        });
+
+        cluster.handleView(view);
+
+        System.out.println("-- wait command intercept");
+        assertThat(RaftTestUtils.eventually(() -> interceptor.numberOfBlockedMessages() > 0, 10, TimeUnit.SECONDS)).isTrue();
+
+        // While the message is in-flight, the elected leader leaves the cluster.
+        view = createView(view_id++, 0, 1);
+        cluster.handleView(view);
+
+        // We can release the elected message.
+        interceptor.releaseNext();
+        interceptor.assertNoBlockedMessages();
+
+        // Wait until either A or B is elected.
+        System.out.println("-- waiting for leader between A and B");
+        RAFT[] rafts = new RAFT[] { raft(0), raft(1) };
+        BaseRaftElectionTest.waitUntilLeaderElected(rafts, 10_000);
+
+        assertOneLeader();
+        assertThat(leaders())
+                .withFailMessage(this::dumpLeaderAndTerms)
+                .hasSize(1)
+                .containsAnyOf(address(0), address(1));
+    }
+
+    public void testCoordinatorLeaveBeforeSendingElected(Class<?> ignore) throws Exception {
+        long view_id = 0;
+        withClusterSize(3);
+        createCluster();
+
+        View view = createView(view_id++, 0, 1, 2);
+
+        // We intercept the first `LeaderElected` message.
+        AtomicBoolean onlyOnce = new AtomicBoolean(true);
+        BlockingMessageInterceptor interceptor = cluster.addCommandInterceptor(m -> {
+            for (Map.Entry<Short, Header> h : m.getHeaders().entrySet()) {
+                if (h.getValue() instanceof LeaderElected && onlyOnce.getAndSet(false)) {
+                    // Assert that node C was elected
+                    LeaderElected le = (LeaderElected) h.getValue();
+                    assertThat(le.leader()).isEqualTo(address(0));
+                    return true;
+                }
+            }
+            return false;
+        });
+
+        cluster.handleView(view);
+
+        System.out.println("-- wait command intercept");
+        assertThat(RaftTestUtils.eventually(() -> interceptor.numberOfBlockedMessages() > 0, 10, TimeUnit.SECONDS)).isTrue();
+
+        // While the message is in-flight, the elected leader leaves the cluster.
+        view = createView(view_id++, 1, 2);
+
+        System.out.printf("-- install new view %s%n", view);
+        cluster.handleView(view);
+
+        // We can release the elected message.
+        interceptor.releaseNext();
+        interceptor.assertNoBlockedMessages();
+
+        // Wait until either A or B is elected.
+        System.out.println("-- waiting for leader between B and C");
+        RAFT[] rafts = new RAFT[] { raft(1), raft(2) };
+        BaseRaftElectionTest.waitUntilLeaderElected(rafts, 10_000);
+
+        assertThat(clusterLeaders(1, 2)).withFailMessage(this::dumpLeaderAndTerms)
+                .hasSize(1)
+                .containsAnyOf(address(1), address(2));
+
+        // Operations on node A fail!
+        RaftAssertion.assertLeaderlessOperationThrows(() -> raft(0).set(new byte[0], 0, 0, 500, TimeUnit.MILLISECONDS));
+
+        // Operations on other nodes succeed.
+        RAFT leader = leader(1, 2);
+        leader.set(new byte[0], 0, 0, 1, TimeUnit.SECONDS);
+
+        long termBeforeJoin = leader.currentTerm();
+
+        System.out.println("-- installing new view with previous coordinator back");
+        // Include the previous coordinator again.
+        cluster.add(address(0), node(0));
+        cluster.handleView(createView(view_id++, 1, 2, 0));
+
+        RaftTestUtils.eventually(() -> Objects.equals(raft(0).leader(), leader.getAddress()), 5, TimeUnit.SECONDS);
+        assertThat(raft(0).leader()).isEqualTo(leader.getAddress());
+        assertThat(raft(0).currentTerm()).isEqualTo(termBeforeJoin);
+    }
+
+    private RAFT leader(int ... indexes) {
+        return IntStream.of(indexes)
+                .mapToObj(this::raft)
+                .filter(Objects::nonNull)
+                .filter(RAFT::isLeader)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private void setLog(RAFT raft, int... terms) {
+        Log log = raft.log();
+        long index = log.lastAppended();
+        LogEntries le = new LogEntries();
+        for (int term : terms)
+            le.add(new LogEntry(term, BUF));
+        log.append(index + 1, le);
+    }
+
+    private List<Address> clusterLeaders(int ... indexes) {
+        return IntStream.of(indexes)
+                .mapToObj(this::raft)
+                .filter(Objects::nonNull)
+                .filter(RAFT::isLeader)
+                .map(RAFT::getAddress)
+                .collect(Collectors.toList());
+    }
+
+    // Checks that there is 1 leader in the cluster and the rest are followers
+    protected void assertOneLeader() {
+        long count = Arrays.stream(nodes())
+                .filter(Objects::nonNull)
+                .map(RaftNode::raft)
+                .filter(RAFT::isLeader)
+                .count();
+        assertThat(count).as(this::dumpLeaderAndTerms).isOne();
+    }
+
+    @Override
+    protected void amendRAFTConfiguration(RAFT raft) {
+        raft.synchronous(true).stateMachine(new DummyStateMachine());
+    }
+}


### PR DESCRIPTION
More details on #259.

When the elected leader leaves before the voting thread has finished and a majority is present. This causes a liveness issue on both ELECTION and ELECTION2. We can fix this by stopping the voting thread before starting it again.

Scenarios the coordinator leaves before finishing the election process and a majority still exists. The ELECTION algorithm has a liveness issue since it does not verify changes in the view coordinator. We handle this case by calculating if the coordinator has changed between views, there is a majority, it is currently the coordinator, and there is no leader.
