### PR TITLE
Handle leader leaving during election procedure

### DIFF
--- a/src/org/jgroups/protocols/raft/ELECTION.java
+++ b/src/org/jgroups/protocols/raft/ELECTION.java
@@ -48,12 +48,12 @@ public class ELECTION extends BaseElection {
 
     @Override
     protected void handleView(View v) {
+        View view = this.view; this.view = v; // assign view before check on the election result
         Majority result=Utils.computeMajority(view, v, raft().majority(), raft.leader());
-        log.debug("%s: existing view: %s, new view: %s, result: %s", local_addr, this.view, v, result);
-        List<Address> joiners=View.newMembers(this.view, v);
+        log.debug("%s: existing view: %s, new view: %s, result: %s", local_addr, view, v, result);
+        List<Address> joiners=View.newMembers(view, v);
         boolean has_new_members=joiners != null && !joiners.isEmpty();
-        boolean coordinatorChanged = Utils.viewCoordinatorChanged(this.view, v);
-        this.view=v;
+        boolean coordinatorChanged = Utils.viewCoordinatorChanged(view, v);
         switch(result) {
             case no_change:
                 // the leader resends its term/address for new members to set the term/leader.

--- a/src/org/jgroups/protocols/raft/ELECTION.java
+++ b/src/org/jgroups/protocols/raft/ELECTION.java
@@ -48,12 +48,13 @@ public class ELECTION extends BaseElection {
 
     @Override
     protected void handleView(View v) {
-        View view = this.view; this.view = v; // assign view before check on the election result
-        Majority result=Utils.computeMajority(view, v, raft().majority(), raft.leader());
-        log.debug("%s: existing view: %s, new view: %s, result: %s", local_addr, view, v, result);
-        List<Address> joiners=View.newMembers(view, v);
+        View previousView = this.view;
+        this.view = v;
+        Majority result=Utils.computeMajority(previousView, v, raft().majority(), raft.leader());
+        log.debug("%s: existing view: %s, new view: %s, result: %s", local_addr, previousView, v, result);
+        List<Address> joiners=View.newMembers(previousView, v);
         boolean has_new_members=joiners != null && !joiners.isEmpty();
-        boolean coordinatorChanged = Utils.viewCoordinatorChanged(view, v);
+        boolean coordinatorChanged = Utils.viewCoordinatorChanged(previousView, v);
         switch(result) {
             case no_change:
                 // the leader resends its term/address for new members to set the term/leader.
@@ -72,7 +73,6 @@ public class ELECTION extends BaseElection {
                 // See: https://github.com/jgroups-extras/jgroups-raft/issues/259
                 if(isViewCoordinator()) {
                     log.trace("%s: starting voting process (reason: %s, view: %s)", local_addr, result, view);
-                    stopVotingThread();
                     startVotingThread();
                 }
                 break;

--- a/src/org/jgroups/protocols/raft/ELECTION2.java
+++ b/src/org/jgroups/protocols/raft/ELECTION2.java
@@ -69,13 +69,12 @@ public class ELECTION2 extends BaseElection {
 
     @Override
     protected void handleView(View v) {
-        Majority result = Utils.computeMajority(view, v, raft().majority(), raft.leader());
-        log.debug("%s: existing view: %s, new view: %s, result: %s", local_addr, this.view, v, result);
-
-        View old_view = this.view;
+        View previousView = this.view;
         this.view = v;
+        Majority result = Utils.computeMajority(previousView, v, raft().majority(), raft.leader());
+        log.debug("%s: existing view: %s, new view: %s, result: %s", local_addr, previousView, v, result);
 
-        List<Address> joiners = View.newMembers(old_view, v);
+        List<Address> joiners = View.newMembers(previousView, v);
         boolean has_new_members = joiners != null && !joiners.isEmpty();
 
         switch (result) {
@@ -86,7 +85,7 @@ public class ELECTION2 extends BaseElection {
                 }
                 // If we have no change in terms of majority threshold. If the view coordinator changed, we need to
                 // verify if an election is necessary.
-                if (Utils.viewCoordinatorChanged(old_view, v) && isViewCoordinator() && view.size() >= raft.majority()) {
+                if (Utils.viewCoordinatorChanged(previousView, v) && isViewCoordinator() && view.size() >= raft.majority()) {
                     preVotingMechanism.start();
                 }
                 break;

--- a/src/org/jgroups/protocols/raft/election/BaseElection.java
+++ b/src/org/jgroups/protocols/raft/election/BaseElection.java
@@ -330,8 +330,10 @@ public abstract class BaseElection extends Protocol {
     }
 
     public synchronized BaseElection startVotingThread() {
-        if(!isVotingThreadRunning())
+        if(!isVotingThreadRunning()) {
+            log.debug("%s: starting the voting thread", local_addr);
             voting_thread.start();
+        }
         return this;
     }
 

--- a/src/org/jgroups/raft/testfwk/MockRaftCluster.java
+++ b/src/org/jgroups/raft/testfwk/MockRaftCluster.java
@@ -153,8 +153,8 @@ public abstract class MockRaftCluster {
      * @return The {@link Executor} instance to utilize in the cluster abstraction.
      */
     protected Executor createThreadPool(long max_idle_ms) {
-        int max_cores = Math.max(Runtime.getRuntime().availableProcessors(), 4);
-        return new ThreadPoolExecutor(0, max_cores, max_idle_ms, TimeUnit.MILLISECONDS,
+        // Same as Executors.newCachedThreadPool();
+        return new ThreadPoolExecutor(0, Integer.MAX_VALUE, max_idle_ms, TimeUnit.MILLISECONDS,
                 new SynchronousQueue<>());
     }
 

--- a/src/org/jgroups/raft/testfwk/RaftNode.java
+++ b/src/org/jgroups/raft/testfwk/RaftNode.java
@@ -132,7 +132,7 @@ public class RaftNode extends Protocol implements Lifecycle, Settable, Closeable
     @SuppressWarnings("unchecked")
     protected <T extends Protocol> T find(Class<T> cl) {
         for(Protocol p: prots) {
-            if(p.getClass().isAssignableFrom(cl))
+            if(cl.isAssignableFrom(p.getClass()))
                 return (T)p;
         }
         return null;

--- a/tests/junit-functional/org/jgroups/tests/SyncElectionTests.java
+++ b/tests/junit-functional/org/jgroups/tests/SyncElectionTests.java
@@ -211,6 +211,7 @@ public class SyncElectionTests extends BaseRaftElectionTest.ClusterBased<RaftClu
         // All nodes but the previous leader.
         int[] indexes = IntStream.range(0, clusterSize).filter(i -> i != leader).toArray();
         waitUntilLeaderElected(5_000, indexes);
+        waitUntilVotingThreadStops(5_000, indexes);
 
         System.out.printf("%s\n", print());
         assertOneLeader();

--- a/tests/junit-functional/org/jgroups/tests/SyncLeaderCrashTest.java
+++ b/tests/junit-functional/org/jgroups/tests/SyncLeaderCrashTest.java
@@ -76,6 +76,7 @@ public class SyncLeaderCrashTest extends BaseRaftElectionTest.ClusterBased<RaftC
         assertIndices(7, 4);
 
         RAFT leader=Stream.of(rafts()).filter(r -> r != null && r.isLeader()).findFirst().orElse(null);
+        System.out.printf("-- new leader: %s%n", leader);
         assert leader != null;
         System.out.printf("-- Leader: %s, commit-table:\n%s\n", leader.getAddress(), leader.commitTable());
 

--- a/tests/junit-functional/org/jgroups/tests/election/DelayedElectedLeaderMessageTest.java
+++ b/tests/junit-functional/org/jgroups/tests/election/DelayedElectedLeaderMessageTest.java
@@ -1,0 +1,107 @@
+package org.jgroups.tests.election;
+
+import org.jgroups.Global;
+import org.jgroups.Header;
+import org.jgroups.View;
+import org.jgroups.protocols.raft.election.LeaderElected;
+import org.jgroups.raft.testfwk.BlockingMessageInterceptor;
+import org.jgroups.raft.testfwk.RaftCluster;
+import org.jgroups.tests.harness.BaseRaftElectionTest;
+import org.jgroups.tests.harness.RaftAssertion;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jgroups.raft.testfwk.RaftTestUtils.eventually;
+import static org.jgroups.tests.harness.BaseRaftElectionTest.ALL_ELECTION_CLASSES_PROVIDER;
+
+@Test(groups = Global.FUNCTIONAL, singleThreaded = true, dataProvider = ALL_ELECTION_CLASSES_PROVIDER)
+public class DelayedElectedLeaderMessageTest extends BaseRaftElectionTest.ClusterBased<RaftCluster> {
+
+    /**
+     * Use blocking interceptor to capture LeaderElected.
+     * Install complete view to succeed in the election process.
+     * While the message is blocked, remove the majority of nodes.
+     * After new view installed, remove the interceptor.
+     * The node should not install the leader.
+     */
+
+    private static final byte[] BUF = {};
+
+    {
+        createManually = true;
+    }
+
+    @AfterMethod
+    protected void destroy() throws Exception {
+        destroyCluster();
+    }
+
+    public void testQuorumLostAfterMessageSent(Class<?> ignore) throws Exception {
+        long viewId = 0;
+        withClusterSize(5);
+        createCluster();
+
+        // Create complete view to successfully elect a node.
+        // Use a cluster of 5 nodes.
+        View v1 = createView(viewId++, 0, 1, 2, 3, 4);
+
+        // Run asynchronously to allow the voting thread to stop.
+        cluster.async(true);
+
+        // Intercept the first `LeaderElected` message.
+        AtomicBoolean onlyOnce = new AtomicBoolean(true);
+        BlockingMessageInterceptor interceptor = cluster.addCommandInterceptor(m -> {
+            for (Map.Entry<Short, Header> h : m.getHeaders().entrySet()) {
+                if (h.getValue() instanceof LeaderElected && onlyOnce.getAndSet(false)) {
+                    // Assert the coordinator was elected.
+                    LeaderElected le = (LeaderElected) h.getValue();
+                    assertThat(le.leader()).isEqualTo(address(0));
+                    return true;
+                }
+            }
+            return false;
+        });
+
+        // Install view and elect the coordinator.
+        cluster.handleView(v1);
+
+        // Intercept the leader elected message.
+        System.out.println("-- wait command intercept");
+        assertThat(eventually(() -> interceptor.numberOfBlockedMessages() > 0, 10, TimeUnit.SECONDS)).isTrue();
+
+        // Install the new view while the LeaderElected is in-flight.
+        // The new view does not have a majority.
+        System.out.println("-- install new view without majority");
+        View v2 = createView(viewId++, 0, 1);
+        cluster.handleView(v2);
+
+        // Release the leader elected message.
+        // The node should not install the new leader.
+        System.out.println("-- release leader elected message");
+        interceptor.releaseNext();
+        interceptor.assertNoBlockedMessages();
+
+        // Make sure the leader stays null for the whole time.
+        BooleanSupplier bs = () -> Arrays.stream(rafts())
+                .anyMatch(r -> r.leader() != null);
+        assertThat(eventually(bs, 3, TimeUnit.SECONDS))
+                .withFailMessage(this::dumpLeaderAndTerms)
+                .isFalse();
+
+        assertThat(bs.getAsBoolean()).isFalse();
+        RaftAssertion.assertLeaderlessOperationThrows(() -> raft(0).set(BUF, 0, 0));
+    }
+
+    @Override
+    protected RaftCluster createNewMockCluster() {
+        return new RaftCluster();
+    }
+}

--- a/tests/junit-functional/org/jgroups/tests/election/DetermineLeaderBreakdownTest.java
+++ b/tests/junit-functional/org/jgroups/tests/election/DetermineLeaderBreakdownTest.java
@@ -1,0 +1,204 @@
+package org.jgroups.tests.election;
+
+import org.jgroups.Address;
+import org.jgroups.Global;
+import org.jgroups.View;
+import org.jgroups.protocols.raft.ELECTION;
+import org.jgroups.protocols.raft.Log;
+import org.jgroups.protocols.raft.LogEntries;
+import org.jgroups.protocols.raft.LogEntry;
+import org.jgroups.protocols.raft.RAFT;
+import org.jgroups.protocols.raft.election.BaseElection;
+import org.jgroups.raft.testfwk.RaftCluster;
+import org.jgroups.tests.harness.BaseRaftElectionTest;
+import org.jgroups.tests.harness.CheckPoint;
+import org.jgroups.tests.harness.RaftAssertion;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BooleanSupplier;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jgroups.raft.testfwk.RaftTestUtils.eventually;
+
+@Test(groups = Global.FUNCTIONAL, singleThreaded = true, dataProvider = "determine-data-provider")
+public class DetermineLeaderBreakdownTest extends BaseRaftElectionTest.ClusterBased<RaftCluster> {
+
+    private static final byte[] BUF = {};
+
+    private CheckPoint checkPoint;
+
+    {
+        createManually = true;
+        checkPoint = new CheckPoint();
+    }
+
+    @AfterMethod
+    protected void destroy() throws Exception {
+        destroyCluster();
+        checkPoint = new CheckPoint();
+    }
+
+    public void testQuorumLostWhileDeterminingLeader(Class<?> ignore) throws Exception {
+        long viewId = 0;
+        withClusterSize(3);
+        createCluster();
+
+        triggerForever("%s_DETERMINE_IN_CONTINUE", 1, 2);
+        triggerForever("%s_DETERMINE_OUT_CONTINUE", 1, 2);
+
+        // Install view with all members needed for election to succeed.
+        View v1 = createView(viewId++, 0, 1, 2);
+        cluster.handleView(v1);
+
+        // Wait until trying to determine leader.
+        checkPoint.awaitStrict("A_DETERMINE_IN", 10, TimeUnit.SECONDS);
+        checkPoint.trigger("A_DETERMINE_IN_CONTINUE");
+
+        // Leader `A` is selected based on the complete view with all the votes.
+        checkPoint.awaitStrict("A_DETERMINE_OUT", 10, TimeUnit.SECONDS);
+
+        // Install new view without quorum needed for safety.
+        View v2 = createView(viewId++, 0);
+        cluster.handleView(v2);
+
+        assertThat(raft(0).leader()).isNull();
+        assertThat(election(0).isVotingThreadRunning()).isFalse();
+
+        // Let the method return and install A as leader.
+        checkPoint.trigger("A_DETERMINE_OUT_CONTINUE");
+
+        System.out.println("-- waiting leader to remain null without majority");
+
+        // Utilize the eventually method to make sure the leader is always null in the next 3 seconds.
+        BooleanSupplier bs = () -> raft(0).leader() != null;
+        assertThat(eventually(bs, 3, TimeUnit.SECONDS))
+                .withFailMessage(this::dumpLeaderAndTerms)
+                .isFalse();
+
+        // Assert not possible to send operation.
+        RaftAssertion.assertLeaderlessOperationThrows(() -> raft(0).set(BUF, 0, 0));
+    }
+
+    public void testDeterminedLeaderLeave(Class<?> ignore) throws Exception {
+        long viewId = 0;
+        withClusterSize(3);
+        createCluster();
+
+        triggerForever("%s_DETERMINE_IN_CONTINUE", 1, 2);
+        triggerForever("%s_DETERMINE_OUT_CONTINUE", 1, 2);
+
+        // Node `C` has the longest log.
+        setLog(raft(2), 1, 1, 1, 1);
+
+        // Install new view to trigger election.
+        View v1 = createView(viewId++, 0, 1, 2);
+        cluster.handleView(v1);
+
+        // Wait until trying to determine leader.
+        checkPoint.awaitStrict("A_DETERMINE_IN", 10, TimeUnit.SECONDS);
+
+        // Determines the leader based on view {A, B, C}.
+        checkPoint.triggerForever("A_DETERMINE_IN_CONTINUE");
+        checkPoint.awaitStrict("A_DETERMINE_OUT", 10, TimeUnit.SECONDS);
+
+        // Now all the votes are collected for view {A, B, C}, where `C` should be elected.
+        // However, we change the view removing C before the leader is set locally.
+        View v2 = createView(viewId++, 0, 1);
+        cluster.handleView(v2);
+
+        // Check leader is still null before the return.
+        assertThat(raft(0).leader()).isNull();
+        long term = raft(0).currentTerm();
+
+        // Let the method return and try to install C as leader.
+        checkPoint.triggerForever("A_DETERMINE_OUT_CONTINUE");
+
+        // The coordinator identifies the view change and the leader is lost.
+        // The voting thread should run again to try elect in the new view.
+        System.out.println("-- waiting new leader elected");
+        waitUntilLeaderElected(10_000, 0, 1);
+
+        // Assert the new leader is either A or B.
+        assertThat(leaders())
+                .withFailMessage(this::dumpLeaderAndTerms)
+                .hasSize(1)
+                .containsAnyElementsOf(List.of(address(0), address(1)));
+
+        // Since another voting round is triggered, the term is increased.
+        assertThat(term).isLessThan(raft(0).currentTerm());
+    }
+
+    private void triggerForever(String template, int ... indexes) {
+        for (int index : indexes) {
+            RAFT r = raft(index);
+            if (r == null) continue;
+
+            checkPoint.triggerForever(String.format(template, r.raftId()));
+        }
+    }
+
+    private void setLog(RAFT raft, int... terms) {
+        Log log = raft.log();
+        long index = log.lastAppended();
+        LogEntries le = new LogEntries();
+        for (int term : terms)
+            le.add(new LogEntry(term, BUF));
+        log.append(index + 1, le);
+    }
+
+    @Override
+    protected RaftCluster createNewMockCluster() {
+        return new RaftCluster();
+    }
+
+    @Override
+    protected BaseElection createNewElection() throws Exception {
+        BaseElection be = super.createNewElection();
+        ((DetermineLeaderCheckpoint) be).checkPoint = checkPoint;
+        return be;
+    }
+
+    @DataProvider(name = "determine-data-provider")
+    protected Object[][] dataProvider() {
+        return new Object[][] {
+                { DetermineLeaderCheckpoint.class }
+        };
+    }
+
+    public static class DetermineLeaderCheckpoint extends ELECTION {
+        private CheckPoint checkPoint;
+
+        public DetermineLeaderCheckpoint() {
+            setId(ELECTION_ID);
+            level("trace");
+        }
+
+        @Override
+        protected Address determineLeader() {
+            checkPoint.trigger(String.format("%s_DETERMINE_IN", raft.raftId()));
+            checkPoint.uncheckedAwaitStrict(String.format("%s_DETERMINE_IN_CONTINUE", raft.raftId()), 10, TimeUnit.SECONDS);
+
+            Address a = super.determineLeader();
+
+            checkPoint.trigger(String.format("%s_DETERMINE_OUT", raft.raftId()));
+            while (true) {
+                try {
+                    checkPoint.awaitStrict(String.format("%s_DETERMINE_OUT_CONTINUE", raft.raftId()), 10, TimeUnit.SECONDS);
+                    break;
+                } catch (InterruptedException e) {
+                    Thread.interrupted();
+                } catch (TimeoutException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            return a;
+        }
+    }
+}

--- a/tests/junit-functional/org/jgroups/tests/election/LeaderLeavingTest.java
+++ b/tests/junit-functional/org/jgroups/tests/election/LeaderLeavingTest.java
@@ -1,0 +1,125 @@
+package org.jgroups.tests.election;
+
+import org.jgroups.Address;
+import org.jgroups.Global;
+import org.jgroups.View;
+import org.jgroups.protocols.raft.Log;
+import org.jgroups.protocols.raft.LogEntries;
+import org.jgroups.protocols.raft.LogEntry;
+import org.jgroups.protocols.raft.RAFT;
+import org.jgroups.raft.testfwk.RaftCluster;
+import org.jgroups.tests.DummyStateMachine;
+import org.jgroups.tests.harness.BaseRaftElectionTest;
+import org.jgroups.tests.harness.CheckPoint;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jgroups.tests.harness.BaseRaftElectionTest.ALL_ELECTION_CLASSES_PROVIDER;
+
+@Test(groups = Global.FUNCTIONAL, singleThreaded = true, dataProvider = ALL_ELECTION_CLASSES_PROVIDER)
+public class LeaderLeavingTest extends BaseRaftElectionTest.ClusterBased<RaftCluster> {
+
+    private final static byte[] BUF = {};
+    private CheckPoint checkPoint;
+
+    {
+        createManually = true;
+        checkPoint = new CheckPoint();
+    }
+
+    @AfterMethod
+    protected void destroy() throws Exception {
+        destroyCluster();
+        checkPoint = new CheckPoint();
+    }
+
+    public void testLeaderLeftDuringElection(Class<?> ignore) throws Exception {
+        long viewId = 0;
+        withClusterSize(3);
+        createCluster();
+
+        // Set a long log for node B so it is elected leader.
+        setLog(raft(1), 1, 1, 1, 1);
+
+        // Trigger forever so we don't block on other nodes.
+        checkPoint.triggerForever("C_ENTER_SET_LAT_CONTINUE");
+        checkPoint.triggerForever("B_ENTER_SET_LAT_CONTINUE");
+
+        // Asynchronously install the view. Running in the same thread can deadlock.
+        View v1 = createView(viewId++, 0, 1, 2);
+        CompletableFuture<Void> f1 = async(() -> cluster.handleView(v1));
+
+        // Await until node A (the coordinator) tries to install the new elected leader.
+        // We block the operation and change the view removing the elected leader.
+        checkPoint.awaitStrict("A_ENTER_SET_LAT", 10, SECONDS);
+        System.out.println("-- installing second view without leader");
+        View v2 = createView(viewId++, 0, 2);
+        CompletableFuture<Void> f2 = async(() -> cluster.handleView(v2));
+
+        // Let the voting thread continue processing.
+        // It will send the elected message for the previous leader B.
+        // But since it left the cluster, the election keeps running.
+        checkPoint.triggerForever("A_ENTER_SET_LAT_CONTINUE");
+
+        System.out.println("-- waiting leader to be elected between remaining nodes");
+        // A new leader is elected.
+        waitUntilLeaderElected(10_000, 0, 2);
+
+        // Assert the leader is one of the remaining nodes.
+        assertThat(leader(0, 1))
+                .withFailMessage(this::dumpLeaderAndTerms)
+                .satisfiesAnyOf(
+                        r -> assertThat(r.raftId()).isEqualTo(raft(0).raftId()),
+                        r -> assertThat(r.raftId()).isEqualTo(raft(2).raftId()));
+
+        f1.get(10, SECONDS);
+        f2.get(10, SECONDS);
+    }
+
+    private void setLog(RAFT raft, int... terms) {
+        Log log = raft.log();
+        long index = log.lastAppended();
+        LogEntries le = new LogEntries();
+        for (int term : terms)
+            le.add(new LogEntry(term, BUF));
+        log.append(index + 1, le);
+    }
+
+    private RAFT leader(int ... indexes) {
+        return IntStream.of(indexes)
+                .mapToObj(this::raft)
+                .filter(Objects::nonNull)
+                .filter(RAFT::isLeader)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    @Override
+    protected RAFT newRaftInstance() {
+        return new RAFT() {
+            @Override
+            public RAFT setLeaderAndTerm(Address new_leader, long new_term) {
+                checkPoint.trigger(String.format("%s_ENTER_SET_LAT", raft_id));
+                checkPoint.uncheckedAwaitStrict(String.format("%s_ENTER_SET_LAT_CONTINUE", raft_id), 10, SECONDS);
+                return super.setLeaderAndTerm(new_leader, new_term);
+            }
+        };
+    }
+
+    @Override
+    protected RaftCluster createNewMockCluster() {
+        return new RaftCluster();
+    }
+
+    @Override
+    protected void amendRAFTConfiguration(RAFT raft) {
+        raft.synchronous(true).stateMachine(new DummyStateMachine());
+    }
+}

--- a/tests/junit-functional/org/jgroups/tests/election/NetworkPartitionElectionTest.java
+++ b/tests/junit-functional/org/jgroups/tests/election/NetworkPartitionElectionTest.java
@@ -78,7 +78,6 @@ public class NetworkPartitionElectionTest extends BaseRaftElectionTest.ClusterBa
         // Store who's the leader before merging.
         assertThat(leaders()).hasSize(1);
         RAFT leader = raft(leaders().get(0));
-        long leaderTermBefore = leader.currentTerm();
 
         System.out.printf("-- merge partition, leader=%s%n", leader);
         // Join the partitions.

--- a/tests/junit-functional/org/jgroups/tests/election/VotingThreadBreakdownTest.java
+++ b/tests/junit-functional/org/jgroups/tests/election/VotingThreadBreakdownTest.java
@@ -1,0 +1,142 @@
+package org.jgroups.tests.election;
+
+import org.jgroups.Global;
+import org.jgroups.View;
+import org.jgroups.protocols.raft.ELECTION;
+import org.jgroups.protocols.raft.RAFT;
+import org.jgroups.protocols.raft.election.BaseElection;
+import org.jgroups.raft.testfwk.RaftCluster;
+import org.jgroups.tests.harness.BaseRaftElectionTest;
+import org.jgroups.tests.harness.CheckPoint;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Test(groups = Global.FUNCTIONAL, singleThreaded = true, dataProvider = "voting-thread-checkpoint")
+public class VotingThreadBreakdownTest extends BaseRaftElectionTest.ClusterBased<RaftCluster> {
+
+    private CheckPoint checkPoint;
+
+    {
+        createManually = true;
+        checkPoint = new CheckPoint();
+    }
+
+    @AfterMethod
+    protected void destroy() throws Exception {
+        destroyCluster();
+        checkPoint = new CheckPoint();
+    }
+
+    public void testMajorityLostAndGained(Class<?> ignore) throws Exception {
+        long viewId = 0;
+        withClusterSize(3);
+        createCluster();
+
+        // Disable checkpoint for the other nodes.
+        triggerForever("%s_STOP_METHOD_IN_WAIT", 1, 2);
+        triggerForever("%s_START_METHOD_IN_WAIT", 1, 2);
+
+        // Install view with majority to trigger the election mechanism.
+        View v1 = createView(viewId++, 0, 1, 2);
+        System.out.println("-- installing first view with all members");
+        CompletableFuture<Void> f1 = async(() -> cluster.handleView(v1));
+
+        // New view starts the voting thread.
+        checkPoint.awaitStrict("A_START_METHOD_IN", 100, TimeUnit.SECONDS);
+
+        // Install new view without majority.
+        View v2 = createView(viewId++, 0);
+        CompletableFuture<Void> f2 = async(() -> cluster.handleView(v2));
+        checkPoint.awaitStrict("A_STOP_METHOD_IN", 100, TimeUnit.SECONDS);
+        checkPoint.trigger("A_STOP_METHOD_IN_WAIT");
+
+        f2.get(10, TimeUnit.SECONDS);
+
+        // Let the original start voting thread run.
+        // Trigger forever so subsequent starts can happen automatically without waiting.
+        checkPoint.triggerForever("A_START_METHOD_IN_WAIT");
+        f1.get(10, TimeUnit.SECONDS);
+
+        // It will verify the majority is lost and try stop the voting thread.
+        // We install the new view while the coordinator is trying to stop the voting thread.
+        //checkPoint.awaitStrict("A_STOP_METHOD_IN", 10, TimeUnit.SECONDS);
+        View v3 = createView(viewId++, 0, 1, 2);
+
+        System.out.printf("-- installing complete view: %s%n", v3);
+        cluster.add(node(1).getAddress(), node(1));
+        cluster.add(node(2).getAddress(), node(2));
+        CompletableFuture<Void> f3 = async(() -> cluster.handleView(v3));
+
+        // Let the voting thread stop.
+        // Trigger forever so the election can proceed without waiting.
+        checkPoint.triggerForever("A_STOP_METHOD_IN_WAIT");
+
+        // A leader should still be elected.
+        waitUntilLeaderElected(10_000, 0, 1, 2);
+        f3.get(10, TimeUnit.SECONDS);
+    }
+
+    private void triggerForever(String template, int ... indexes) {
+        for (int index : indexes) {
+            RAFT r = raft(index);
+            if (r == null) continue;
+
+            checkPoint.triggerForever(String.format(template, r.raftId()));
+        }
+    }
+
+    @Override
+    protected RaftCluster createNewMockCluster() {
+        return new RaftCluster();
+    }
+
+    @Override
+    protected BaseElection createNewElection() throws Exception {
+        BaseElection be = super.createNewElection();
+        ((VotingThreadCheckpoint) be).checkPoint = checkPoint;
+        return be;
+    }
+
+    @DataProvider(name = "voting-thread-checkpoint")
+    protected Object[][] dataProvider() {
+        return new Object[][] {
+                { VotingThreadCheckpoint.class }
+        };
+    }
+
+    public static class VotingThreadCheckpoint extends ELECTION {
+        private CheckPoint checkPoint;
+
+        public VotingThreadCheckpoint() {
+            setId(ELECTION_ID);
+        }
+
+        @Override
+        public BaseElection stopVotingThread() {
+            checkPoint.trigger(String.format("%s_STOP_METHOD_IN", raft.raftId()));
+            try {
+                checkPoint.awaitStrict(String.format("%s_STOP_METHOD_IN_WAIT", raft.raftId()), 10, TimeUnit.SECONDS);
+            } catch (InterruptedException | TimeoutException e) {
+                throw new RuntimeException(e);
+            }
+            return super.stopVotingThread();
+        }
+
+        @Override
+        public BaseElection startVotingThread() {
+            checkPoint.trigger(String.format("%s_START_METHOD_IN", raft.raftId()));
+            try {
+                checkPoint.awaitStrict(String.format("%s_START_METHOD_IN_WAIT", raft.raftId()), 10, TimeUnit.SECONDS);
+            } catch (InterruptedException | TimeoutException e) {
+                throw new RuntimeException(e);
+            }
+            return super.startVotingThread();
+        }
+    }
+}

--- a/tests/junit-functional/org/jgroups/tests/harness/CheckPoint.java
+++ b/tests/junit-functional/org/jgroups/tests/harness/CheckPoint.java
@@ -1,0 +1,260 @@
+package org.jgroups.tests.harness;
+
+import org.jgroups.util.CompletableFutures;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Behaves more or less like a map of {@link java.util.concurrent.Semaphore}s.
+ * <p>
+ * One thread will wait for an event via {@code await(...)} or {@code awaitStrict(...)}, and one or more
+ * other threads will trigger the event via {@code trigger(...)} or {@code triggerForever(...)}.
+ * </p>
+ *
+ * @author Dan Berindei
+ * @see <a href="https://github.com/infinispan/infinispan">Infinispan</a>
+ */
+public class CheckPoint {
+
+   public static final int INFINITE = 999999999;
+
+   private final String id;
+   private final Lock lock = new ReentrantLock();
+   private final Condition unblockCondition = lock.newCondition();
+   private final Map<String, EventStatus> events = new HashMap<>();
+
+   public CheckPoint() {
+      this.id = "";
+   }
+
+   public CheckPoint(String name) {
+      this.id = "[" + name + "] ";
+   }
+
+   public void awaitStrict(String event, long timeout, TimeUnit unit)
+         throws InterruptedException, TimeoutException {
+      awaitStrict(event, 1, timeout, unit);
+   }
+
+   public void uncheckedAwaitStrict(String event, long timeout, TimeUnit unit) {
+       try {
+           awaitStrict(event, timeout, unit);
+       } catch (InterruptedException | TimeoutException e) {
+           throw new RuntimeException(e);
+       }
+   }
+
+   public CompletionStage<Void> awaitStrictAsync(String event, long timeout, TimeUnit unit, Executor executor) {
+      return CompletableFuture.runAsync(() -> {
+         try {
+            awaitStrict(event, 1, timeout, unit);
+         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+         } catch (TimeoutException e) {
+            rethrowExceptionIfPresent(e);
+         }
+      }, executor);
+   }
+
+   public void awaitStrict(String event, int count, long timeout, TimeUnit unit)
+         throws InterruptedException, TimeoutException {
+      if (!await(event, count, timeout, unit)) {
+         throw new TimeoutException(id + "Timed out waiting for event " + event);
+      }
+   }
+
+   private static void rethrowExceptionIfPresent(Throwable t) {
+      if (t != null) {
+         throw asCompletionException(t);
+      }
+   }
+
+   private static CompletionException asCompletionException(Throwable t) {
+      if (t instanceof CompletionException) {
+         return ((CompletionException) t);
+      } else {
+         return new CompletionException(t);
+      }
+   }
+
+   private boolean await(String event, int count, long timeout, TimeUnit unit) throws InterruptedException {
+      System.out.printf("%sWaiting for event %s * %d%n", id, event, count);
+      lock.lock();
+      try {
+         EventStatus status = events.computeIfAbsent(event, k -> new EventStatus());
+         long waitNanos = unit.toNanos(timeout);
+         while (waitNanos > 0) {
+            if (status.available >= count) {
+               status.available -= count;
+               break;
+            }
+            waitNanos = unblockCondition.awaitNanos(waitNanos);
+         }
+
+         if (waitNanos <= 0) {
+            System.err.printf("%sTimed out waiting for event %s * %d (available = %d, total = %d)%n",
+                       id, event, count, status.available, status.total);
+            // let the triggering thread know that we timed out
+            status.available = -1;
+            return false;
+         }
+
+         System.out.printf("%sReceived event %s * %d (available = %d, total = %d)%n", id, event, count, status.available, status.total);
+         return true;
+      } finally {
+         lock.unlock();
+      }
+   }
+
+   public String peek(long timeout, TimeUnit unit, String... expectedEvents) throws InterruptedException {
+      System.out.printf("%sWaiting for any one of events %s%n", id, Arrays.toString(expectedEvents));
+      String found = null;
+      lock.lock();
+      try {
+         long waitNanos = unit.toNanos(timeout);
+         while (waitNanos > 0) {
+            for (String event : expectedEvents) {
+               EventStatus status = events.get(event);
+               if (status != null && status.available >= 1) {
+                  found = event;
+                  break;
+               }
+            }
+            if (found != null)
+               break;
+
+            waitNanos = unblockCondition.awaitNanos(waitNanos);
+         }
+
+         if (waitNanos <= 0) {
+            System.out.printf("%sPeek did not receive any of %s%n", id, Arrays.toString(expectedEvents));
+            return null;
+         }
+
+         EventStatus status = events.get(found);
+         System.out.printf("%sReceived event %s (available = %d, total = %d)%n", id, found, status.available, status.total);
+         return found;
+      } finally {
+         lock.unlock();
+      }
+   }
+
+   public CompletableFuture<Void> future(String event, long timeout, TimeUnit unit, Executor executor) {
+      return future(event, 1, timeout, unit, executor);
+   }
+
+   public CompletableFuture<Void> future(String event, int count, long timeout, TimeUnit unit, Executor executor) {
+      return future0(event, count)
+              .orTimeout(timeout, unit)
+              .thenRunAsync(() -> System.out.printf("Received event %s * %d%n", event, count), executor);
+   }
+
+   public CompletableFuture<Void> future0(String event, int count) {
+      System.out.printf("%sWaiting for event %s * %d%n", id, event, count);
+      lock.lock();
+      try {
+         EventStatus status = events.computeIfAbsent(event, k -> new EventStatus());
+         if (status.available >= count) {
+            status.available -= count;
+            return CompletableFutures.completedNull();
+         }
+         if (status.requests == null) {
+            status.requests = new ArrayList<>();
+         }
+         CompletableFuture<Void> f = new CompletableFuture<>();
+         status.requests.add(new Request(f, count));
+         return f;
+      } finally {
+         lock.unlock();
+      }
+   }
+
+   public void trigger(String event) {
+      trigger(event, 1);
+   }
+
+   public void triggerForever(String event) {
+      trigger(event, INFINITE);
+   }
+
+   public void trigger(String event, int count) {
+      lock.lock();
+      try {
+         EventStatus status = events.get(event);
+         if (status == null) {
+            status = new EventStatus();
+            events.put(event, status);
+         } else if (status.available < 0) {
+            throw new IllegalStateException(id + "Thread already timed out waiting for event " + event);
+         }
+
+         // If triggerForever is called more than once, it will cause an overflow and the waiters will fail.
+         status.available = count != INFINITE ? status.available + count : INFINITE;
+         status.total = count != INFINITE ? status.total + count : INFINITE;
+         System.out.printf("%sTriggering event %s * %d (available = %d, total = %d)%n", id, event, count,
+                    status.available, status.total);
+         unblockCondition.signalAll();
+         if (status.requests != null) {
+            if (count == INFINITE) {
+               status.requests.forEach(request -> request.future.complete(null));
+            } else {
+               Iterator<Request> iterator = status.requests.iterator();
+               while (status.available > 0 && iterator.hasNext()){
+                  Request request = iterator.next();
+                  if (request.count <= status.available) {
+                     request.future.complete(null);
+                     status.available -= request.count;
+                     iterator.remove();
+                  }
+               }
+            }
+         }
+      } finally {
+         lock.unlock();
+      }
+   }
+
+   @Override
+   public String toString() {
+      return "CheckPoint(" + id + ")" + events;
+   }
+
+   private static class EventStatus {
+      int available;
+      int total;
+      public ArrayList<Request> requests;
+
+      @Override
+      public String toString() {
+         return available + "/" + total + ", requests=" + requests;
+      }
+   }
+
+   private static class Request {
+      final CompletableFuture<Void> future;
+      final int count;
+
+      private Request(CompletableFuture<Void> future, int count) {
+         this.future = future;
+         this.count = count;
+      }
+
+      @Override
+      public String toString() {
+         return "(" + count + ")";
+      }
+   }
+}


### PR DESCRIPTION
Borrowing ideas from #284. We check whether the elected leader is still present in the current view. If the leader has left, the voting thread continues running, collecting proposals from the new view.

The first commit includes a test for the case the leader left before the coordinator applied the result locally. The test reproduces the issue described in #280.

The third commit contains a check when handling the `LeaderElected` message. The node verifies if the leader is present in the current view.