### PR TITLE
Windows specific file methods

### DIFF
--- a/src/org/jgroups/protocols/raft/LevelDBLog.java
+++ b/src/org/jgroups/protocols/raft/LevelDBLog.java
@@ -1,6 +1,9 @@
 package org.jgroups.protocols.raft;
 
-import org.iq80.leveldb.*;
+import static org.fusesource.leveldbjni.JniDBFactory.factory;
+import static org.jgroups.raft.util.LongHelper.fromByteArrayToLong;
+import static org.jgroups.raft.util.LongHelper.fromLongToByteArray;
+
 import org.jgroups.Address;
 import org.jgroups.logging.LogFactory;
 import org.jgroups.util.Util;
@@ -12,9 +15,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.ObjLongConsumer;
 
-import static org.fusesource.leveldbjni.JniDBFactory.factory;
-import static org.jgroups.raft.util.LongHelper.fromByteArrayToLong;
-import static org.jgroups.raft.util.LongHelper.fromLongToByteArray;
+import org.iq80.leveldb.DB;
+import org.iq80.leveldb.DBIterator;
+import org.iq80.leveldb.Options;
+import org.iq80.leveldb.WriteBatch;
+import org.iq80.leveldb.WriteOptions;
 
 /**
  * Implementation of {@link Log}
@@ -221,6 +226,7 @@ public class LevelDBLog implements Log {
             byte[] v=e.getValue();
             size+=v != null? v.length : 0;
         }
+        Util.close(it);
         return size;
     }
 

--- a/src/org/jgroups/raft/testfwk/RaftTestUtils.java
+++ b/src/org/jgroups/raft/testfwk/RaftTestUtils.java
@@ -81,6 +81,7 @@ public final class RaftTestUtils {
     public static void deleteRaftLog(RAFT r) throws Exception {
         Log log = r != null ? r.log() : null;
         if (log != null) {
+            log.close();
             log.delete();
             r.log(null);
         }

--- a/tests/junit-functional/org/jgroups/tests/LogTest.java
+++ b/tests/junit-functional/org/jgroups/tests/LogTest.java
@@ -35,6 +35,7 @@ public class LogTest {
 
     @AfterMethod protected void destroy() throws Exception {
         if(log != null) {
+            log.close();
             log.delete();
             log=null;
         }


### PR DESCRIPTION
* Avoid using mmap on Windows;
* Create file wrapper for file operations in Windows;
* Call close before deleting log files;
* Close dangling LevelDB iterator.

Closes #281 and #295