### PR TITLE
[#18] Implement read-only operations

### DIFF
--- a/src/org/jgroups/protocols/raft/CLIENT.java
+++ b/src/org/jgroups/protocols/raft/CLIENT.java
@@ -37,7 +37,7 @@ public class CLIENT extends Protocol implements Runnable {
     protected static final short  CLIENT_ID = 523;
     protected static final byte[] BUF={};
 
-    public enum RequestType {set_req, add_server, remove_server, type, rsp}
+    public enum RequestType {set_req, add_server, remove_server, type, rsp, get_req}
 
     static {
         ClassConfigurator.addProtocol(CLIENT_ID, CLIENT.class);
@@ -163,6 +163,8 @@ public class CLIENT extends Protocol implements Runnable {
                     case set_req:
                         settable.setAsync(buffer, 0, buffer.length).whenComplete(completion_handler);
                         break;
+                    case get_req:
+                        settable.getAsync(buffer, 0, buffer.length, null).whenComplete(completion_handler);
                     case add_server:
                         dyn_membership.addServer(Util.bytesToString(buffer)).whenComplete(completion_handler);
                         break;

--- a/src/org/jgroups/protocols/raft/Leader.java
+++ b/src/org/jgroups/protocols/raft/Leader.java
@@ -27,6 +27,7 @@ public class Leader extends RaftImpl {
         super.init();
         raft.createRequestTable();
         raft.createCommitTable();
+        raft.createReadOnlyRequestRepository();
     }
 
     public void destroy() {
@@ -36,6 +37,7 @@ public class Leader extends RaftImpl {
         raft.commit_table=null;
 
         if (reqTable != null) reqTable.destroy(raft.notCurrentLeader());
+        if (raft.readOnlyRequests != null) raft.readOnlyRequests.destroy();
     }
 
 
@@ -56,6 +58,7 @@ public class Leader extends RaftImpl {
                 if (!Utils.isRaftMember(sender_raft_id, raft.members()))
                     break;
 
+                raft.readOnlyRequests.commit(raft.commit_index);
                 boolean done = reqtab.add(result.index, sender_raft_id, this.majority);
                 if(done) {
                     raft.commitLogTo(result.index, true);

--- a/src/org/jgroups/protocols/raft/RaftImpl.java
+++ b/src/org/jgroups/protocols/raft/RaftImpl.java
@@ -43,7 +43,7 @@ public abstract class RaftImpl {
         raft.leader(leader);
         long curr_index=prev_index+1;
         // we got an empty AppendEntries message containing only leader_commit, or the index is below the commit index
-        if(entries == null || curr_index <= raft.commitIndex()) {
+        if(entries == null || entries.size() == 0 || curr_index <= raft.commitIndex()) {
             raft.commitLogTo(leader_commit, false);
             return new AppendResult(OK, raft.lastAppended()).commitIndex(raft.commitIndex());
         }

--- a/src/org/jgroups/raft/RaftHandle.java
+++ b/src/org/jgroups/raft/RaftHandle.java
@@ -101,5 +101,8 @@ public class RaftHandle implements Settable {
         return settable.setAsync(buf, offset, length, options);
     }
 
-
+    @Override
+    public CompletableFuture<byte[]> getAsync(byte[] buf, int offset, int length, Options options) throws Exception {
+        return settable.getAsync(buf, offset, length, options);
+    }
 }

--- a/src/org/jgroups/raft/Settable.java
+++ b/src/org/jgroups/raft/Settable.java
@@ -41,9 +41,32 @@ public interface Settable {
         return future.get(timeout, unit);
     }
 
+    /**
+     * Synchronous get operation bounded by a timeout.
+     * <p>
+     * This method blocks until the change has been committed or a timeout occurred.
+     * </p>
+     *
+     * @param buf The buffer representing the read-only operation to submit to the state machine.
+     * @param offset The offset to skip the bytes in the buffer.
+     * @param length The number of bytes to use from the buffer starting at offset.
+     * @param timeout The operation timeout value.
+     * @param unit The unit of the operation timeout value.
+     * @return A buffer representing the result after submitting the read-only operation.
+     * @throws Exception Thrown if the operation could not be submitted.
+     * @see #getAsync(byte[], int, int, Options)
+     */
+    default byte[] get(byte[] buf, int offset, int length, long timeout, TimeUnit unit) throws Exception {
+        CompletableFuture<byte[]> cf = getAsync(buf, offset, length, null);
+        return cf.get(timeout, unit);
+    }
 
     default CompletableFuture<byte[]> setAsync(byte[] buf, int offset, int length) throws Exception {
         return setAsync(buf, offset, length, null);
+    }
+
+    default CompletableFuture<byte[]> getAsync(byte[] buf, int offset, int length) throws Exception {
+        return getAsync(buf, offset, length, null);
     }
 
     /**
@@ -56,4 +79,25 @@ public interface Settable {
      * @return A CompletableFuture which can be used to fetch the result.
      */
     CompletableFuture<byte[]> setAsync(byte[] buf, int offset, int length, Options options) throws Exception;
+
+    /**
+     * Asynchronous get operation that returns immediately without blocking.
+     * <p>
+     * This method submits a read-only operation to the state machine. Read-only operations are treated differently by
+     * the replication algorithm. Since read-only operations <b>do not</b> change the state-machine state, these operations
+     * are not appended to the replicated log.
+     * </p>
+     *
+     * <p>
+     * <#>Warning:</b> Do not change the state-machine state by operations submitted through this method. Otherwise, the
+     * state-machine will diverge and lead to an undefined state.
+     * </p>
+     *
+     * @param buf The buffer representing the read-only operation to submit to the state machine.
+     * @param offset The offset to skip the bytes in the buffer.
+     * @param length The number of bytes to use from the buffer starting at offset.
+     * @return A buffer representing the result after submitting the read-only operation.
+     * @throws Exception Thrown if the operation could not be submitted.
+     */
+    CompletableFuture<byte[]> getAsync(byte[] buf, int offset, int length, Options options) throws Exception;
 }

--- a/src/org/jgroups/raft/client/ClientStub.java
+++ b/src/org/jgroups/raft/client/ClientStub.java
@@ -74,6 +74,11 @@ public class ClientStub implements Settable, Closeable {
         return setAsync(CLIENT.RequestType.set_req, buf, offset, length);
     }
 
+    @Override
+    public CompletableFuture<byte[]> getAsync(byte[] buf, int offset, int length, Options ignored) throws Exception {
+        return setAsync(CLIENT.RequestType.get_req, buf, offset, length);
+    }
+
     public CompletableFuture<byte[]> setAsync(CLIENT.RequestType type,
                                               byte[] buf, int offset, int length) throws Exception {
            CompletableFuture<byte[]> req=new CompletableFuture<>();

--- a/src/org/jgroups/raft/testfwk/RaftNode.java
+++ b/src/org/jgroups/raft/testfwk/RaftNode.java
@@ -120,6 +120,10 @@ public class RaftNode extends Protocol implements Lifecycle, Settable, Closeable
         return raft.setAsync(buf, offset, length, false, options);
     }
 
+    @Override
+    public CompletableFuture<byte[]> getAsync(byte[] buf, int offset, int length, Options options) throws Exception {
+        return raft.getAsync(buf, offset, length, options);
+    }
 
     public String toString() {
         return Stream.of(prots)

--- a/src/org/jgroups/raft/util/CounterStateMachine.java
+++ b/src/org/jgroups/raft/util/CounterStateMachine.java
@@ -26,7 +26,7 @@ public class CounterStateMachine implements StateMachine {
         int val=Bits.readInt(data, offset);
         if(val < 0)
             subtractions.incrementAndGet();
-        else
+        else if (val > 0)
             additions.incrementAndGet();
         int old_counter=counter.get();
         counter.addAndGet(val);

--- a/src/org/jgroups/raft/util/ReadOnlyRequestRepository.java
+++ b/src/org/jgroups/raft/util/ReadOnlyRequestRepository.java
@@ -1,0 +1,171 @@
+package org.jgroups.raft.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Repository for read-only operations.
+ *
+ * <p>
+ * This repository utilizes an ordered set to map between a log index and multiple pending requests. Read-only operations
+ * in {@link org.jgroups.protocols.raft.RAFT} do not update the log index, in contrast with {@link RequestTable}. This
+ * maps multiple requests to the same index in the log, or the same key in the requests map.
+ * </p>
+ *
+ * @param <R> The type of requests.
+ * @author José Bolina
+ * @since 1.1.2
+ */
+public final class ReadOnlyRequestRepository<R> {
+
+    private final NavigableMap<Long, Entry> requests = new TreeMap<>(Long::compareTo);
+    private final Supplier<Integer> majority;
+    private final Consumer<Collection<R>> listener;
+    private final Consumer<Collection<R>> destroyer;
+    private boolean destroyed;
+
+    private ReadOnlyRequestRepository(Supplier<Integer> majority, Consumer<Collection<R>> listener, Consumer<Collection<R>> destroyer) {
+        this.majority = majority;
+        this.listener = listener;
+        this.destroyer = destroyer;
+        this.destroyed = false;
+    }
+
+    /**
+     * Invokes the registered destroyer with all pending requests.
+     *
+     * <p>
+     * Subsequent calls to register operations after destroy will automatically invoke the destroyer listener.
+     * </p>
+     */
+    public void destroy() {
+        destroyed = true;
+        for (Entry value : requests.values()) {
+            destroyer.accept(value.requests);
+        }
+        requests.clear();
+    }
+
+    /**
+     * Advances the commit index.
+     * <p>
+     * Once the commit index advances, this method will complete the requests up-to, and including, the index. The listener
+     * is invoked for all requests in the range.
+     * </p>
+     *
+     * @param index The current index the log was advanced to.
+     */
+    public void advance(long index) {
+        Iterator<Map.Entry<Long, Entry>> it = requests.headMap(index, true).entrySet().iterator();
+        while (it.hasNext()) {
+            Entry v = it.next().getValue();
+            listener.accept(v.requests);
+            it.remove();
+        }
+    }
+
+    /**
+     * Register an accept from a follower to the given index.
+     * <p>
+     * Register the accept response of a single follower node to all requests of a given index and below. The completion
+     * listener is invoked once a majority of accepts is registered.
+     * </p>
+     *
+     * @param index The index accepted by the follower node.
+     */
+    public void commit(long index) {
+        Iterator<Map.Entry<Long, Entry>> it = requests.headMap(index, true).entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<Long, Entry> me = it.next();
+            Entry v = me.getValue();
+            v.accepted();
+            if (v.isCommitted()) {
+                listener.accept(v.requests);
+                it.remove();
+            }
+        }
+    }
+
+    /**
+     * Register a new request submitted at the given index.
+     * <p>
+     * If the repository was already destroyed by invoking {@link #destroy()}, the destroyer listener is invoked with
+     * the provided request.
+     * </p>
+     *
+     * @param index The commit index at the time the request was submitted.
+     * @param request The request to store.
+     */
+    public void register(long index, R request) {
+        if (destroyed) {
+            destroyer.accept(Collections.singletonList(request));
+            return;
+        }
+
+        requests.compute(index, (k, v) -> {
+            if (v == null) return new Entry(request);
+
+            v.include(request);
+            return v;
+        });
+    }
+
+    public static <R> Builder<R> builder(Supplier<Integer> majority) {
+        return new Builder<>(majority);
+    }
+
+    private final class Entry {
+        private final Collection<R> requests;
+
+        // Leader creating the request already counts towards operation quorum.
+        private int acceptors = 1;
+
+        public Entry(R request) {
+            this.requests = new ArrayList<>();
+            requests.add(request);
+        }
+
+        public void include(R request) {
+            requests.add(request);
+        }
+
+        public void accepted() {
+            acceptors++;
+        }
+
+        public boolean isCommitted() {
+            return acceptors >= majority.get();
+        }
+    }
+
+    public static final class Builder<R> {
+        private final Supplier<Integer> majority;
+        private Consumer<Collection<R>> listener = ignore -> {};
+        private Consumer<Collection<R>> destroyer = ignore -> {};
+
+        private Builder(Supplier<Integer> majority) {
+            this.majority = majority;
+        }
+
+        public Builder<R> withCommitter(Consumer<Collection<R>> committer) {
+            this.listener = committer;
+            return this;
+        }
+
+        public Builder<R> withDestroyer(Consumer<Collection<R>> destroyer) {
+            this.destroyer = destroyer;
+            return this;
+        }
+
+        public ReadOnlyRequestRepository<R> build() {
+            return new ReadOnlyRequestRepository<>(majority, listener, destroyer);
+        }
+    }
+}

--- a/tests/junit-functional/org/jgroups/tests/utils/ReadOnlyRequestRepositoryTest.java
+++ b/tests/junit-functional/org/jgroups/tests/utils/ReadOnlyRequestRepositoryTest.java
@@ -1,0 +1,129 @@
+package org.jgroups.tests.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jgroups.Global;
+import org.jgroups.raft.util.ReadOnlyRequestRepository;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.testng.annotations.Test;
+
+@Test(groups = Global.FUNCTIONAL, singleThreaded = true)
+public class ReadOnlyRequestRepositoryTest {
+
+    public void testMajorityReached() {
+        AtomicInteger count = new AtomicInteger();
+        CompletableFuture<Void> cf = new CompletableFuture<>();
+        ReadOnlyRequestRepository<CompletableFuture<Void>> repository = ReadOnlyRequestRepository.<CompletableFuture<Void>>builder(() -> 2)
+                .withCommitter(cfs -> {
+                    assertThat(cfs.size()).isOne();
+                    cfs.forEach(c -> c.complete(null));
+                    count.incrementAndGet();
+                })
+                .build();
+
+        repository.register(10, cf);
+        assertThat(cf.isDone()).isFalse();
+        assertThat(count.get()).isZero();
+
+        // Lower commit index doesn't affect.
+        repository.commit(9);
+        assertThat(cf.isDone()).isFalse();
+        assertThat(count.get()).isZero();
+
+        repository.commit(10);
+        assertThat(cf.isDone()).isTrue();
+        assertThat(count.get()).isOne();
+
+        repository.commit(10);
+        assertThat(count.get()).isOne();
+    }
+
+    public void testCommitAdvance() {
+        CompletableFuture<Void> cf = new CompletableFuture<>();
+        ReadOnlyRequestRepository<CompletableFuture<Void>> repository = ReadOnlyRequestRepository.<CompletableFuture<Void>>builder(() -> 20)
+                .withCommitter(cfs -> {
+                    assertThat(cfs.size()).isOne();
+                    cfs.forEach(c -> c.complete(null));
+                })
+                .build();
+
+        repository.register(10, cf);
+        assertThat(cf.isDone()).isFalse();
+
+        repository.commit(10);
+        assertThat(cf.isDone()).isFalse();
+
+        repository.advance(11);
+        assertThat(cf.isDone()).isTrue();
+    }
+
+    public void testDestroyCompletePendingRequests() {
+        CompletableFuture<Void> cf = new CompletableFuture<>();
+        AtomicInteger counter = new AtomicInteger();
+        ReadOnlyRequestRepository<CompletableFuture<Void>> repository = ReadOnlyRequestRepository.<CompletableFuture<Void>>builder(() -> 20)
+                .withDestroyer(cfs -> {
+                    assertThat(cfs.size()).isOne();
+                    counter.incrementAndGet();
+                    cfs.forEach(c -> c.complete(null));
+                })
+                .build();
+
+        repository.register(10, cf);
+        assertThat(cf.isDone()).isFalse();
+
+        repository.destroy();
+        assertThat(cf.isDone()).isTrue();
+        assertThat(counter.get()).isOne();
+
+        // Registering after destroy will automatically invoke the destroyer.
+        repository.register(10, cf);
+        assertThat(counter.get()).isEqualTo(2);
+    }
+
+    public void testMajorityChange() {
+        AtomicInteger majority = new AtomicInteger(2);
+        CompletableFuture<Void> cf = new CompletableFuture<>();
+        ReadOnlyRequestRepository<CompletableFuture<Void>> repository = ReadOnlyRequestRepository.<CompletableFuture<Void>>builder(majority::get)
+                .withCommitter(cfs -> {
+                    assertThat(cfs.size()).isOne();
+                    cfs.forEach(c -> c.complete(null));
+                })
+                .build();
+
+        repository.register(10, cf);
+
+        // Majority was initiated with 2, but now it updates to 3. This means it needs two commits.
+        majority.set(3);
+        repository.commit(10);
+        assertThat(cf.isDone()).isFalse();
+
+        repository.commit(10);
+        assertThat(cf.isDone()).isTrue();
+    }
+
+    public void testCommitIsUpTo() {
+        AtomicInteger count = new AtomicInteger();
+        CompletableFuture<Void> cf = new CompletableFuture<>();
+        ReadOnlyRequestRepository<CompletableFuture<Void>> repository = ReadOnlyRequestRepository.<CompletableFuture<Void>>builder(() -> 2)
+                .withCommitter(cfs -> {
+                    assertThat(cfs.size()).isOne();
+                    cfs.forEach(c -> c.complete(null));
+                    count.incrementAndGet();
+                })
+                .build();
+
+        assertThat(count.get()).isZero();
+        // We register the request at index 5 and 8, but will commit with higher commits.
+        repository.register(5, cf);
+        repository.register(8, cf);
+
+        repository.commit(10);
+        assertThat(cf.isDone()).isTrue();
+
+        // Since it committed up-to 10, listener is invoked for 5 and 8.
+        assertThat(count.get()).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
* Add method for read-only operations in Settable interface.
* Method is implemented by RAFT and REDIRECT.
* Apply read-only operations after committing the log entries. The operations are stored in a dedicated repository.

I am opening as a PR to associated with GH issue. I'll integrate right away. Closes #18.
Some numbers running with IspnPerf:

| Description                                                 | Read % | Throughput |
|-------------------------------------------------------------|--------|------------|
| 2025-09-05 jdk=21.0.2+13-58 jg=5.5.0 v=1.1.1.Final          | 80%    | 9584.77    |
| 2025-09-05 jdk=21.0.2+13-58 jg=5.5.0 v=1.1.2.Final-SNAPSHOT | 80%    | 14144.81   |
| 2025-09-05 jdk=21.0.2+13-58 jg=5.5.0 v=1.1.1.Final          | 100%   | 9101.47    |
| 2025-09-05 jdk=21.0.2+13-58 jg=5.5.0 v=1.1.2.Final-SNAPSHOT | 100%   | 64198.75   |

We create a read-only repository in the leader. This repository will map a collection of requests to a given index. The append entries request is still submitted to all the follower because we need to make sure the node is the leader to maintain linearizability. Once the follower reply arrives, we invoke the `commit(long)` method with the log index accepted by the followers. Once the majority commits the index `I`, we accept all batched requests with index `<= I`.

Right now, I am using a NavigableMap to store the requests by index and iterate in order. I can see an improvement here to coalesce everything into a single repository for read and writes. We would need to use the ring buffer with a collection of elements per index. We could accept the read-only requests from the tail up-to the commit index.
